### PR TITLE
Allow disabling BungeeCord check.

### DIFF
--- a/divinemc-server/minecraft-patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
+++ b/divinemc-server/minecraft-patches/sources/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
+@@ -168,7 +_,7 @@
+                 if (split.length == 4) {
+                     this.connection.spoofedProfile = ServerHandshakePacketListenerImpl.gson.fromJson(split[3], com.mojang.authlib.properties.Property[].class);
+                 }
+-            } else if ((split.length == 3 || split.length == 4) && (ServerHandshakePacketListenerImpl.HOST_PATTERN.matcher(split[1]).matches())) {
++            } else if (!org.bxteam.divinemc.config.DivineConfig.config.getBoolean("remove-bungeecord-check") && (split.length == 3 || split.length == 4) && (ServerHandshakePacketListenerImpl.HOST_PATTERN.matcher(split[1]).matches())) {
+                 Component message = Component.literal("Unknown data in login hostname, did you forget to enable BungeeCord in spigot.yml?");
+                 this.connection.send(new ClientboundLoginDisconnectPacket(message));
+                 this.connection.disconnect(message);

--- a/divinemc-server/src/main/java/org/bxteam/divinemc/config/DivineConfig.java
+++ b/divinemc-server/src/main/java/org/bxteam/divinemc/config/DivineConfig.java
@@ -781,6 +781,7 @@ public class DivineConfig {
         public static boolean sendSpectatorChangePacket = true;
         public static boolean playerProfileResultCachingEnabled = true;
         public static int playerProfileResultCachingTimeout = 1440;
+        public static boolean removeBungeeCordCheckEnabled = false;
 
         // No chat reports
         public static boolean noChatReportsEnabled = false;
@@ -822,6 +823,8 @@ public class DivineConfig {
                 "Enables caching of player profile results on first join.");
             playerProfileResultCachingTimeout = getInt(ConfigCategory.NETWORK.key("player-profile-result-caching.timeout"), playerProfileResultCachingTimeout,
                 "The amount of time in minutes to cache player profile results.");
+            removeBungeeCordCheckEnabled = getBoolean(ConfigCategory.NETWORK.key("remove-bungeecord-check"), removeBungeeCordCheckEnabled,
+                "Disables the BungeeCord check added by Spigot. This allows for the use of Velocity/BungeeCord proxies. If this is enabled, you must ensure that the proper security configurations are in place.");
         }
 
         private static void noChatReports() {


### PR DESCRIPTION
I would like to suggest the addition of a setting which can be used to disable the BungeeCord check ("remove-bungeecord-check"). This feature originates from the Leaf project.

With a setting like this, players would be able to set up a Velocity/BungeeCord proxy. Although it requires a more advanced configuration, this feature could potentially be helpful to some server owners.

If you guys feel that a setting like this would be a nice addition to DivineMC, I've already added the code to the DivineConfig class in my pull request. I've also pasted a draft of the code change that would be required for the ServerHandshakePacketListenerImpl class below.

`!org.bxteam.divinemc.config.DivineConfig.config.getBoolean("remove-bungeecord-check") && (split.length == 3 || split.length == 4) && (ServerHandshakePacketListenerImpl.HOST_PATTERN.matcher(split[1]).matches())`