### PR TITLE
[1.21.6] Update paperweight patcher plugin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     java
-    id("io.papermc.paperweight.patcher") version "2.0.0-SNAPSHOT"
+    id("io.papermc.paperweight.patcher") version "2.0.0-beta.17"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"


### PR DESCRIPTION
Changed the paperweight patcher Gradle plugin from version `2.0.0-SNAPSHOT` to `2.0.0-beta.17`

Java Version I Use
```
Monci@LAPTOP-ARV04JGB:~/Source-Codes/DivineMC$ java --version
java 21.0.9 2025-10-21 LTS
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79, mixed mode, sharing)
```

Error When using `2.0.0-SNAPSHOT`
```
Monci@LAPTOP-ARV04JGB:~/Source-Codes/DivineMC$ ./gradlew applyAllPatches
Calculating task graph as no cached configuration is available for tasks: applyAllPatches

[Incubating] Problems report is available at: file:///home/Monci/Source-Codes/DivineMC/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'DivineMC'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve io.papermc.paperweight:paperweight-core:2.0.0-SNAPSHOT.
     Required by:
         root project : > io.papermc.paperweight.patcher:io.papermc.paperweight.patcher.gradle.plugin:2.0.0-SNAPSHOT:20251127.230913-168
      > No matching variant of io.papermc.paperweight:paperweight-core:2.0.0-SNAPSHOT:20251127.230913-184 was found. The consumer was configured to find a library for use during runtime, compatible with Java 21, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.14' but:
          - Variant 'javadocElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 21)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.14')
          - Variant 'shadowRuntimeElements' declares a library for use during runtime, compatible with Java 17, packaged as a jar, and its dependencies repackaged (shadow jar):
              - Incompatible because this component declares a component, as well as attribute 'org.gradle.plugin.api-version' with value '9.0.0' and the consumer needed a component, as well as attribute 'org.gradle.plugin.api-version' with value '8.14'
          - Variant 'sourcesElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 21)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.14')

* Try:
> No matching variant errors are explained in more detail at https://docs.gradle.org/8.14/userguide/variant_model.html#sub:variant-no-match.
> Review the variant matching algorithm at https://docs.gradle.org/8.14/userguide/variant_attributes.html#sec:abm_algorithm.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 653ms
```