### PR TITLE
Update default permissions for the "/divinemc" command.

### DIFF
--- a/divinemc-server/src/main/java/org/bxteam/divinemc/command/subcommands/MSPTCommand.java
+++ b/divinemc-server/src/main/java/org/bxteam/divinemc/command/subcommands/MSPTCommand.java
@@ -31,7 +31,7 @@ public final class MSPTCommand extends DivineSubCommandPermission {
     private static final Component SLASH = Component.text("/");
 
     public MSPTCommand() {
-        super(PERM, PermissionDefault.TRUE);
+        super(PERM, PermissionDefault.OP);
     }
 
     @Override

--- a/divinemc-server/src/main/java/org/bxteam/divinemc/command/subcommands/VersionCommand.java
+++ b/divinemc-server/src/main/java/org/bxteam/divinemc/command/subcommands/VersionCommand.java
@@ -16,7 +16,7 @@ public final class VersionCommand extends DivineSubCommandPermission {
     public static final String PERM = DivineCommand.BASE_PERM + "." + LITERAL_ARGUMENT;
 
     public VersionCommand() {
-        super(PERM, PermissionDefault.TRUE);
+        super(PERM, PermissionDefault.OP);
     }
 
     @Override


### PR DESCRIPTION
## Suggestion

I would like to suggest changing the default value for some of the permission nodes added by the "/divinemc" command.

At present, all players can execute "/divinemc mspt". Access to the performance data should always be restricted for security reasons. Thus, the "/divinemc mspt" command should only be available to operators by default, just like with the regular "/mspt" command.

Regular players do not need access to "/divinemc version" either. This command should be restricted to operators as well, just like with the "/purpur version" command.

## Changes

This pull request changes the default value of the permission node for the "mspt" and "version" subcommands. Instead of them being granted to all players, the code makes it so that the permission nodes are only granted to operators by default. However, any server owner can still override this using a permissions plugin.