### PR TITLE
Fix "/divinemc" being visible even when a player has no access to any sub-commands.

### DIFF
--- a/divinemc-server/src/main/java/org/bxteam/divinemc/command/DivineCommand.java
+++ b/divinemc-server/src/main/java/org/bxteam/divinemc/command/DivineCommand.java
@@ -24,7 +24,7 @@ import static net.kyori.adventure.text.format.NamedTextColor.RED;
 public final class DivineCommand extends Command {
     public static final String COMMAND_LABEL = "divinemc";
     public static final String BASE_PERM = DivineCommands.COMMAND_BASE_PERM + "." + COMMAND_LABEL;
-    private static final Permission basePermission = new Permission(BASE_PERM, PermissionDefault.TRUE);
+    private static final Permission basePermission = new Permission(BASE_PERM, PermissionDefault.OP);
 
     private static final DivineSubCommand MSPT_SUBCOMMAND = new MSPTCommand();
     private static final DivineSubCommand RELOAD_SUBCOMMAND = new ReloadCommand();


### PR DESCRIPTION
## Suggestion

I would like to suggest restricting the base permission node of the "/divinemc" command to operators.

At present, "/divinemc" is visible in tab complete even when players don't have access to any of the utilities within it. There is no need for the command to be listed if the player has no access to any of the sub-commands. Regular players do not need the base permission node either, as all of the sub-commands are now restricted to operators.

## Changes

This pull request changes the default value of the base permission node to "OP". This fixes the tab complete issue.